### PR TITLE
Update interfaces type definition

### DIFF
--- a/projects/bibliolib-filter/README.md
+++ b/projects/bibliolib-filter/README.md
@@ -76,17 +76,17 @@ Use the component in your app.component.html
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | mode | string | 'filter-order' | The mode of the filter. Can be 'filter', 'order' or 'filter-order'. |
-| orderConfig | FilterConfig.IOrderItemConfig[] | [] | The configuration of the order. |
-| filterConfig | FilterConfig.IFullFilterItemConfig[] | [] | The configuration of the filter. |
-| activeFilterList | FilterConfig.IFullFilterItemConfig[] | [] | The list of active filters. |
+| orderConfig | FilterConfig.OrderItemConfig[] | [] | The configuration of the order. |
+| filterConfig | FilterConfig.FullFilterItemConfig[] | [] | The configuration of the filter. |
+| activeFilterList | FilterConfig.FullFilterItemConfig[] | [] | The list of active filters. |
 | lang | string | 'fr-FR' | The language of the filter : 'fr-FR' or 'en-US'. |
 
 ## Outputs
 
 | Name | Type | Description |
 | --- | --- | --- |
-| orderChange | EventEmitter<FilterConfig.IOrderItemForRequest> | The event emitted when the order is changed. |
-| filterChange | EventEmitter<FilterConfig.IFullFilterItemConfig[]> | The event emitted when the filter is changed. |
+| orderChange | EventEmitter<FilterConfig.OrderItemForRequest> | The event emitted when the order is changed. |
+| filterChange | EventEmitter<FilterConfig.FullFilterItemConfig[]> | The event emitted when the filter is changed. |
 | searchChange | EventEmitter<string> | The event emitted when the search input is changed. |
 
 # License

--- a/projects/bibliolib-filter/package.json
+++ b/projects/bibliolib-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bibliolib-filter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Bibliolib filter",
   "license": "MIT",
   "authors": [

--- a/projects/bibliolib-filter/src/lib/bibliolib-filter.component.ts
+++ b/projects/bibliolib-filter/src/lib/bibliolib-filter.component.ts
@@ -28,13 +28,13 @@ import { OnlyNumbersDirective } from './only-numbers.directive';
 })
 export class BibliolibFilterComponent implements OnInit {
   mode = input.required<'filter' | 'order' | 'filter-order' | 'search-only'>();
-  orderConfig = input<FilterConfig.IOrderItemConfig[]>([]);
-  filterConfig = input<FilterConfig.IFullFilterItemConfig[]>([]);
-  activeFilterList = input<FilterConfig.IFullFilterItemConfig[]>([]);
+  orderConfig = input<FilterConfig.OrderItemConfig[]>([]);
+  filterConfig = input<FilterConfig.FullFilterItemConfig[]>([]);
+  activeFilterList = input<FilterConfig.FullFilterItemConfig[]>([]);
   lang = input<'fr-FR' | 'en-US'>('fr-FR');
 
-  orderChange: OutputEmitterRef<FilterConfig.IOrderItemForRequest> = output<FilterConfig.IOrderItemForRequest>();
-  filterChange: OutputEmitterRef<FilterConfig.IFullFilterItemConfig[]> = output<FilterConfig.IFullFilterItemConfig[]>();
+  orderChange: OutputEmitterRef<FilterConfig.OrderItemForRequest> = output<FilterConfig.OrderItemForRequest>();
+  filterChange: OutputEmitterRef<FilterConfig.FullFilterItemConfig[]> = output<FilterConfig.FullFilterItemConfig[]>();
   searchChange: OutputEmitterRef<string> = output<string>();
 
   @HostListener('document:keydown.escape', ['$event']) onKeydownHandler(event: KeyboardEvent) {
@@ -56,10 +56,10 @@ export class BibliolibFilterComponent implements OnInit {
   }
 
   filterModalState: 'hidden' | 'nav-menu' | 'order-menu' | 'filter-menu' = 'hidden';
-  currentOrder!: FilterConfig.IOrderItemForRequest;
-  currentFilter!: FilterConfig.IFullFilterItemConfig;
+  currentOrder!: FilterConfig.OrderItemForRequest;
+  currentFilter!: FilterConfig.FullFilterItemConfig;
 
-  tempSelectedFilter: FilterConfig.IFullFilterItemConfig[] = [];
+  tempSelectedFilter: FilterConfig.FullFilterItemConfig[] = [];
 
   searchCtrl: FormControl<string> = new FormControl<string>('', { nonNullable: true });
   filterSearchCtrl: FormControl<string> = new FormControl<string>('', { nonNullable: true });
@@ -296,9 +296,9 @@ export class BibliolibFilterComponent implements OnInit {
   /**
    * Permet de déclencher le bon évènement en fonction du type de filtre
    * @param {Event} e Event
-   * @param {FilterConfig.IOrderItemConfig} order FilterConfig.IOrderItemConfig
+   * @param {FilterConfig.OrderItemConfig} order FilterConfig.OrderItemConfig
    */
-  handleCategoryClick(e: Event, filter: FilterConfig.IFullFilterItemConfig) {
+  handleCategoryClick(e: Event, filter: FilterConfig.FullFilterItemConfig) {
     e.stopPropagation();
     switch (filter.type) {
       case 'check':
@@ -527,7 +527,7 @@ export class BibliolibFilterComponent implements OnInit {
     return this.tempSelectedFilter.some(filter => filter.cat === this.currentFilter.cat && filter.values.includes(value));
   }
 
-  setCurrentFilter(value: FilterConfig.IFullFilterItemConfig) {
+  setCurrentFilter(value: FilterConfig.FullFilterItemConfig) {
     this.currentFilter = value;
   }
 

--- a/projects/bibliolib-filter/src/lib/filter-config.model.ts
+++ b/projects/bibliolib-filter/src/lib/filter-config.model.ts
@@ -5,7 +5,7 @@ export declare module FilterConfig {
     /**
      * Interface representing the configuration for an order item.
      */
-    interface IOrderItemConfig {
+    interface OrderItemConfig {
         /**
          * The label of the order item.
          */
@@ -20,7 +20,7 @@ export declare module FilterConfig {
     /**
      * Interface representing the configuration for an order item request.
      */
-    interface IOrderItemForRequest extends IOrderItemConfig {
+    interface OrderItemForRequest extends OrderItemConfig {
         /**
          * The direction of the order, either ascending ('asc') or descending ('desc').
          */
@@ -30,7 +30,7 @@ export declare module FilterConfig {
     /**
      * Interface representing the configuration for a filter item.
      */
-    interface IFilterItemConfig extends IOrderItemConfig {
+    interface FilterItemConfig extends OrderItemConfig {
         /**
          * The type of the filter item.
          * Can be one of 'list', 'date', 'nullOrNot', 'numeric_range', or 'check'.
@@ -41,7 +41,7 @@ export declare module FilterConfig {
     /**
      * Interface representing the full configuration for a filter item.
      */
-    interface IFullFilterItemConfig extends IFilterItemConfig {
+    interface FullFilterItemConfig extends FilterItemConfig {
         /**
          * The values associated with the filter item.
          */

--- a/projects/test-lib/src/app/app.component.ts
+++ b/projects/test-lib/src/app/app.component.ts
@@ -16,12 +16,12 @@ export class AppComponent {
   title = 'test-lib';
 
   mode: 'filter' | 'order' | 'filter-order' | 'search-only' = 'search-only';
-  orderConfig: FilterConfig.IOrderItemConfig[] = [
+  orderConfig: FilterConfig.OrderItemConfig[] = [
     { label: 'Date', cat: 'date' },
     { label: 'Sortie', cat: 'sortie' },
     { label: 'Auteur', cat: 'author' }
   ];
-  filterConfig: FilterConfig.IFullFilterItemConfig[] = [
+  filterConfig: FilterConfig.FullFilterItemConfig[] = [
     {
       label: 'Date',
       cat: 'date',
@@ -76,7 +76,7 @@ export class AppComponent {
       values: []
     }
   ];
-  activeFilterList: FilterConfig.IFullFilterItemConfig[] = [];
+  activeFilterList: FilterConfig.FullFilterItemConfig[] = [];
   dateSignal: WritableSignal<DateTime> = signal<DateTime>({date: '', hour: ''});
 
   images: string [] = [
@@ -120,7 +120,7 @@ export class AppComponent {
 
   }
 
-  onFilterChange(event: FilterConfig.IFullFilterItemConfig[]) {
+  onFilterChange(event: FilterConfig.FullFilterItemConfig[]) {
     console.log(event); 
     this.activeFilterList = [...event].slice();
   }


### PR DESCRIPTION
This pull request focuses on updating the `FilterConfig` type definitions across multiple files to ensure consistency and remove the `I` prefix from interface names. The changes affect the component implementation, configuration models, and documentation.

### Type Definition Updates:
* [`projects/bibliolib-filter/src/lib/bibliolib-filter.component.ts`](diffhunk://#diff-ca0ed90d974ee211ba07fbf863cad13c6b075f5c5539a9f3234f48029573f93fL31-R37): Updated type definitions for `orderConfig`, `filterConfig`, `activeFilterList`, `orderChange`, and `filterChange` to remove the `I` prefix from interface names. [[1]](diffhunk://#diff-ca0ed90d974ee211ba07fbf863cad13c6b075f5c5539a9f3234f48029573f93fL31-R37) [[2]](diffhunk://#diff-ca0ed90d974ee211ba07fbf863cad13c6b075f5c5539a9f3234f48029573f93fL59-R62) [[3]](diffhunk://#diff-ca0ed90d974ee211ba07fbf863cad13c6b075f5c5539a9f3234f48029573f93fL299-R301) [[4]](diffhunk://#diff-ca0ed90d974ee211ba07fbf863cad13c6b075f5c5539a9f3234f48029573f93fL530-R530)
* [`projects/bibliolib-filter/src/lib/filter-config.model.ts`](diffhunk://#diff-45c298c1d966ece629fb9b109e07512c8fa40b0df8ff506541a93da8f67691f7L8-R8): Renamed interfaces by removing the `I` prefix. [[1]](diffhunk://#diff-45c298c1d966ece629fb9b109e07512c8fa40b0df8ff506541a93da8f67691f7L8-R8) [[2]](diffhunk://#diff-45c298c1d966ece629fb9b109e07512c8fa40b0df8ff506541a93da8f67691f7L23-R23) [[3]](diffhunk://#diff-45c298c1d966ece629fb9b109e07512c8fa40b0df8ff506541a93da8f67691f7L33-R33) [[4]](diffhunk://#diff-45c298c1d966ece629fb9b109e07512c8fa40b0df8ff506541a93da8f67691f7L44-R44)

### Documentation Updates:
* [`projects/bibliolib-filter/README.md`](diffhunk://#diff-da0b0717a81bc3fadc44327d545fc9326281e7351319c28971bf82ace68e753dL79-R89): Updated the documentation to reflect the new `FilterConfig` type definitions without the `I` prefix.

### Version Update:
* [`projects/bibliolib-filter/package.json`](diffhunk://#diff-e5ad616e4fa377016fd39b3492f4dd5a1cb8b52d4e687befec9f791fc7ba5f79L3-R3): Bumped the package version from `1.0.4` to `1.0.5`.

### Test Component Updates:
* [`projects/test-lib/src/app/app.component.ts`](diffhunk://#diff-5c901125e7b7a47d1b2a2642d3435867b2a3cdde209022337cf6dd1b9365e144L19-R24): Updated type definitions for `orderConfig`, `filterConfig`, `activeFilterList`, and `onFilterChange` to remove the `I` prefix from interface names. [[1]](diffhunk://#diff-5c901125e7b7a47d1b2a2642d3435867b2a3cdde209022337cf6dd1b9365e144L19-R24) [[2]](diffhunk://#diff-5c901125e7b7a47d1b2a2642d3435867b2a3cdde209022337cf6dd1b9365e144L79-R79) [[3]](diffhunk://#diff-5c901125e7b7a47d1b2a2642d3435867b2a3cdde209022337cf6dd1b9365e144L123-R123)