### PR TITLE
update: increment version to 1.0.10 and modify form control update st…

### DIFF
--- a/projects/bibliolib-filter/package.json
+++ b/projects/bibliolib-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bibliolib-filter",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Bibliolib filter",
   "license": "MIT",
   "authors": [

--- a/projects/bibliolib-filter/src/lib/bibliolib-filter.component.ts
+++ b/projects/bibliolib-filter/src/lib/bibliolib-filter.component.ts
@@ -979,8 +979,8 @@ export class BibliolibFilterComponent implements OnInit, AfterViewInit {
       if (!this.rangeControls[item.cat]) {
         // Si le contrôle n'existe pas, crée-le avec des valeurs par défaut
         this.rangeControls[item.cat] = new FormGroup({
-          min: new FormControl('', { nonNullable: true }), // Valeur par défaut si absente
-          max: new FormControl('', { nonNullable: true }), // Valeur par défaut si absente
+          min: new FormControl('', { nonNullable: true, updateOn: 'blur' }), // Valeur par défaut si absente
+          max: new FormControl('', { nonNullable: true, updateOn: 'blur' }), // Valeur par défaut si absente
         });
         this.attachValueChangeSubscriptions(item.cat);
       } else {


### PR DESCRIPTION
This pull request includes a version update and an improvement to the form control behavior in the `bibliolib-filter` project. The most important changes are:

Version update:

* [`projects/bibliolib-filter/package.json`](diffhunk://#diff-e5ad616e4fa377016fd39b3492f4dd5a1cb8b52d4e687befec9f791fc7ba5f79L3-R3): Updated the version from `1.0.9` to `1.0.10`.

Form control improvement:

* [`projects/bibliolib-filter/src/lib/bibliolib-filter.component.ts`](diffhunk://#diff-ca0ed90d974ee211ba07fbf863cad13c6b075f5c5539a9f3234f48029573f93fL982-R983): Modified the `FormControl` initialization for `min` and `max` to include the `updateOn: 'blur'` option, ensuring that the form controls are updated on blur events.